### PR TITLE
Update UnpublishExtension.ts

### DIFF
--- a/BuildTasks/UnpublishExtension/UnpublishExtension.ts
+++ b/BuildTasks/UnpublishExtension/UnpublishExtension.ts
@@ -6,7 +6,7 @@ async function run() {
         try {
             tfx.arg(["extension", "unpublish", "--no-color"]);
 
-            common.setTfxMarketplaceArguments(tfx, false);
+            common.setTfxMarketplaceArguments(tfx);
             common.validateAndSetTfxManifestArguments(tfx);
             
             const result = tfx.execSync(<any>{ silent: false, failOnStdErr: false });


### PR DESCRIPTION
Hey,
When testing the new 'unpublish' feature, we got a 401 error. When double-checking the pipeline, I noticed that the 'service-url' parameter was missing.
I also checked the code and I notice that the function common.setTfxMarketplaceArguments(tfx, false); is been called with the false parameter.
I am wondering if this is related to the issue.
Thank you!