### PR TITLE
Use Node APIs to replace __dirname

### DIFF
--- a/BuildTasks/PublishVSExtension/v5/Utils.ts
+++ b/BuildTasks/PublishVSExtension/v5/Utils.ts
@@ -1,13 +1,14 @@
 import tl from "azure-pipelines-task-lib";
 import tr from "azure-pipelines-task-lib/toolrunner.js";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 let cacheVsixPublisherExe = "";
 let loggedIn = false;
 
 export function getVsixPublisherExe(): string {
     if (cacheVsixPublisherExe === "") {
-        const vswhereTool = tl.tool(path.join(__dirname, "tools", "vswhere.exe"));
+        const vswhereTool = tl.tool(path.join(path.dirname(fileURLToPath(import.meta.url)), "tools", "vswhere.exe"));
         vswhereTool.line("-version [15.0,) -latest -requires Microsoft.VisualStudio.Component.VSSDK -find VSSDK\\VisualStudioIntegration\\Tools\\Bin\\VsixPublisher.exe");
         const vswhereResult = vswhereTool.execSync({ silent: true } as tr.IExecSyncOptions);
         const vsixPublisherExe = vswhereResult.stdout.trim();


### PR DESCRIPTION
__dirname doesn't exist in ES modules: see https://nodejs.org/docs/latest-v16.x/api/esm.html#no-__filename-or-__dirname.

While more recent versions of Node have `import.meta.dirname`, that didn't exist in Node 16. Luckily, its docs helpfully tell you exactly how its constructed :). https://nodejs.org/docs/latest/api/esm.html#importmetadirname