### PR TITLE
Changes the unzip handling on linux based runners

### DIFF
--- a/BuildTasks/PublishExtension/v4/vsixeditor.ts
+++ b/BuildTasks/PublishExtension/v4/vsixeditor.ts
@@ -140,7 +140,14 @@ export class VSIXEditor {
             zip.arg("*/task.loc.json");
             zip.arg("extension.vsixmanifest");
             zip.arg("extension.vsomanifest");
-            await zip.execAsync();
+            
+            const result = await zip.execAsync({ ignoreReturnCode: true });
+            
+            // unzip returns exit code 11 when some files are not found, but extraction succeeds for existing files
+            // This is acceptable for optional files like task.json and task.loc.json
+            if (result !== 0 && result !== 11) {
+                throw new Error(`unzip extraction failed with exit code: ${result}`);
+            }
         }
         tl.cd(cwd);
     }


### PR DESCRIPTION
On linux based runners, unzip will return an error code 11 when not all requested files were found during extraction. This is actually not an error, since we're requesting more than we need for some types of extensions.

The issue doesn't occur on Windows, since we rely on 7z to do the work there.

This PR changes both v4 and v5 with the updated error code handling.