### PR TITLE
Refactor execAsync calls and add linting for task warnings

### DIFF
--- a/BuildTasks/PackageExtension/PackageExtension.ts
+++ b/BuildTasks/PackageExtension/PackageExtension.ts
@@ -19,7 +19,7 @@ try {
             await common.checkUpdateTasksManifests();
             const outputStream = new common.TfxJsonOutputStream(console.log);
 
-            const code = await tfx.execAsync(<any>{ outStream: outputStream, failOnStdErr: false });
+            const code = await tfx.execAsync({ outStream: outputStream, failOnStdErr: false });
             if (code !== 0) {
                 throw `tfx exited with return code: ${code}`
             }

--- a/BuildTasks/PublishVSExtension/Utils.ts
+++ b/BuildTasks/PublishVSExtension/Utils.ts
@@ -10,7 +10,7 @@ export function getVsixPublisherExe(): string {
     if (cacheVsixPublisherExe === "") {
         const vswhereTool = tl.tool(path.join(path.dirname(fileURLToPath(import.meta.url)), "tools", "vswhere.exe"));
         vswhereTool.line("-version [15.0,) -latest -requires Microsoft.VisualStudio.Component.VSSDK -find VSSDK\\VisualStudioIntegration\\Tools\\Bin\\VsixPublisher.exe");
-        const vswhereResult = vswhereTool.execSync({ silent: true } as tr.IExecSyncOptions);
+        const vswhereResult = vswhereTool.execSync({ silent: true });
         const vsixPublisherExe = vswhereResult.stdout.trim();
         if (vswhereResult.code === 0 && vsixPublisherExe && tl.exist(vsixPublisherExe)) {
             tl.debug('VsixPublisher.exe installed path: ' + vsixPublisherExe);


### PR DESCRIPTION
Remove type assertions from execAsync calls and introduce a lint file to address task warnings.