### PR TITLE
Add group configuration for shared task dependencies in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,6 +27,11 @@ updates:
   - "/BuildTasks/*/"
   schedule:
     interval: "weekly"
+  groups:
+    shared-task-dependencies:
+      patterns:
+      - "*"
+      group-by: dependency-name
   ignore:
   - dependency-name: "azure-pipelines-task-lib"
     update-types: [ "version-update:semver-major" ]


### PR DESCRIPTION
Introduce a grouping configuration for shared task dependencies to optimize updates in Dependabot. This change enhances the management of dependencies by grouping them based on their names.