### PR TITLE
Update azure-pipelines-tasks-azure-arm-rest to version 3.277.1

### DIFF
--- a/BuildTasks/Common-Auth/package-lock.json
+++ b/BuildTasks/Common-Auth/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0"
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1"
       }
     },
     "node_modules/@azure/abort-controller": {

--- a/BuildTasks/Common-Auth/package.json
+++ b/BuildTasks/Common-Auth/package.json
@@ -10,6 +10,6 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0"
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1"
   }
 }

--- a/BuildTasks/ExtensionVersion/package-lock.json
+++ b/BuildTasks/ExtensionVersion/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "uuidv5": "^1.0.0"
       },
       "devDependencies": {}

--- a/BuildTasks/ExtensionVersion/package.json
+++ b/BuildTasks/ExtensionVersion/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "uuidv5": "^1.0.0"
   },
   "devDependencies": {

--- a/BuildTasks/InstallExtension/package-lock.json
+++ b/BuildTasks/InstallExtension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "uuidv5": "^1.0.0"
       },
       "devDependencies": {}

--- a/BuildTasks/InstallExtension/package.json
+++ b/BuildTasks/InstallExtension/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "uuidv5": "^1.0.0"
   },
   "devDependencies": {

--- a/BuildTasks/IsValidExtensionAgent/package-lock.json
+++ b/BuildTasks/IsValidExtensionAgent/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "promise-retry": "^2.0.1",
         "uuidv5": "^1.0.0"
       },

--- a/BuildTasks/IsValidExtensionAgent/package.json
+++ b/BuildTasks/IsValidExtensionAgent/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "promise-retry": "^2.0.1",
     "uuidv5": "^1.0.0"
   },

--- a/BuildTasks/PublishExtension/package-lock.json
+++ b/BuildTasks/PublishExtension/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "7zip-bin": "^5.2.0",
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "uuidv5": "^1.0.0",
         "x2js": "^3.4.4"
       }

--- a/BuildTasks/PublishExtension/package.json
+++ b/BuildTasks/PublishExtension/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "7zip-bin": "^5.2.0",
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "uuidv5": "^1.0.0",
     "x2js": "^3.4.4"
   }

--- a/BuildTasks/PublishVSExtension/package-lock.json
+++ b/BuildTasks/PublishVSExtension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "tmp": "^0.2.7",
         "uuidv5": "^1.0.0"
       },

--- a/BuildTasks/PublishVSExtension/package.json
+++ b/BuildTasks/PublishVSExtension/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "tmp": "^0.2.7",
     "uuidv5": "^1.0.0"
   },

--- a/BuildTasks/ShareExtension/package-lock.json
+++ b/BuildTasks/ShareExtension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "uuidv5": "^1.0.0"
       },
       "devDependencies": {}

--- a/BuildTasks/ShareExtension/package.json
+++ b/BuildTasks/ShareExtension/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "uuidv5": "^1.0.0"
   },
   "devDependencies": {

--- a/BuildTasks/UnpublishExtension/package-lock.json
+++ b/BuildTasks/UnpublishExtension/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "azure-pipelines-task-lib": "^5.278.0",
-        "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+        "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
         "uuidv5": "^1.0.0"
       },
       "devDependencies": {}

--- a/BuildTasks/UnpublishExtension/package.json
+++ b/BuildTasks/UnpublishExtension/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "azure-pipelines-task-lib": "^5.278.0",
-    "azure-pipelines-tasks-azure-arm-rest": "^3.277.0",
+    "azure-pipelines-tasks-azure-arm-rest": "^3.277.1",
     "uuidv5": "^1.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Update the dependency for azure-pipelines-tasks-azure-arm-rest to version 3.277.1 across multiple tasks to ensure compatibility and access to the latest features and fixes.